### PR TITLE
update buffer before returning unmasked value

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -216,7 +216,7 @@
 				};
 
 				input.data($.mask.dataName,function(){
-                    checkVal();
+					checkVal();
 					return $.map(buffer, function(c, i) {
 						return tests[i]&&c!=settings.placeholder ? c : null;
 					}).join('');


### PR DESCRIPTION
setting the value of a textbox (ie $('#id').val('')) does not update the buffer, making the unmasked value invalid.  Calling checkVal before returning the unmasked value fixes this.
