### PR TITLE
Apply/Remove the mask when re-masking a field

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -221,7 +221,42 @@
 					}).join('');
 				})
 
+				function applyMask(rawData) {
+				    var out = [];
+				    for (var i = 0, pos = 0; i < len; i++) {
+					    if (tests[i] && pos < rawData.length) {
+					        out[i] = settings.placeholder;
+						    while (pos < rawData.length) {
+						        pos++;
+							    var c = rawData.charAt(pos - 1);
+							    if (tests[i].test(c)) {
+								    out[i] = c;
+								    break;
+							    }
+						    }
+						    if (pos >= rawData.length)
+						        out[i] = buffer[i];
+					    } else
+					        out[i] = buffer[i];
+				    }
+				    return out.join("");
+				};
+				
+				function stripMask(rawData) {
+				    var outVals = $.map(rawData.split(""), function(c,i) { 
+				        if (tests[i]) 
+				            return c;
+				    });
+				    return outVals.join("");
+				};
+				
+				//  Intialize the buffer with whatever was given to us.
+				if (focusText.length > 0)
+				    buffer = applyMask(focusText).split("");
+
 				if (!input.attr("readonly"))
+					// remove the mask from the buffer and store it
+					input.val(stripMask(buffer.join('')));
 					input
 					.one("unmask", function() {
 						input


### PR DESCRIPTION
There are two problems that I solved with this fix.

1) By initializing the buffer[] to the focus text, I was able to send data to the control and have it be correctly populated.  So, if I clicked on the textbox and immediately hit Escape, the data would stay there.

2) When attempting to re-mask the field, I got some wild results.  Going from a mask of "999-99-99" to "9999999" caused the mask to be nine characters long, adding the placeholder where the original dashes were and causing the input to go into the places where the original mask specified.  (Ugh.  Just not good.)

To recreate:
Begin with a mask:
input.mask('999-99-99', {placeholder:'0'});
Then change the mask dynamically:
input.mask('9999999', {placeholder:'0'});

The fix was to remove the mask when we did the UnMask, storing the original data (NOT the masked data but the actual values entered) into the original text box.

I have only tested this on IE8, so you should probably double check it.
