### PR TITLE
fix issue #41 Characters out of order on android web browsers

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -32,7 +32,7 @@
                             setTimeout(function () { that.setSelectionRange(begin, end); }, 0);
                         }
                         else {
-                            that.setSelectionRange(begin, end);
+                            this.setSelectionRange(begin, end);
                         }
 					} else if (this.createTextRange) {
 						var range = this.createTextRange();


### PR DESCRIPTION
Android browser has a bug in setSelectionRange function as described in
http://code.google.com/p/android/issues/detail?id=15245
http://stackoverflow.com/questions/4861698/focus-textarea-with-caret-after-text-in-android-browser
http://stackoverflow.com/questions/6103476/android-keyboard-and-javascript

I used a workaround suggested in one of the links. Since android browser
cannot be reliably detected, we just add setting for it (for example
tablet browser with mobile mode switched off).
