### PR TITLE
Calling 'completed' handler when a valid value is pasted

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -250,7 +250,7 @@
 					.bind(pasteEventName, function() {
 						setTimeout(function() { 
 							input.caret(checkVal(true)); 
-							if (checkVal(true) == input.val().length)
+							if (settings.completed && checkVal(true) == input.val().length)
 								settings.completed.call(input);
 						}, 0);
 					});


### PR DESCRIPTION
Enough said in title, I think :)

I noticed that the calling of completed handler was being made only by keypressEvent.

Hope this works and I have not made a mistake. 

Tested in Chrome 15 and Firefox 7 with jQuery 1.5.
