### PR TITLE
Add AMD support to jquery.maskedinput

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -1,9 +1,18 @@
 /*
 	Masked Input plugin for jQuery
 	Copyright (c) 2007-@Year Josh Bush (digitalbush.com)
-	Licensed under the MIT license (http://digitalbush.com/projects/masked-input-plugin/#license) 
+	Licensed under the MIT license (http://digitalbush.com/projects/masked-input-plugin/#license)
 	Version: @version
 */
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+}
 (function($) {
 	var pasteEventName = ($.browser.msie ? 'paste' : 'input') + ".mask";
 	var iPhone = (window.orientation != undefined);
@@ -130,7 +139,7 @@
 						var pos = input.caret(),
 							begin = pos.begin,
 							end = pos.end;
-						
+
 						if(end-begin==0){
 							begin=k!=46?seekPrev(begin):(end=seekNext(begin-1));
 							end=k==46?seekNext(end):end;
@@ -255,4 +264,4 @@
 			});
 		}
 	});
-})(jQuery);
+}));


### PR DESCRIPTION
W.r.t. https://github.com/digitalBush/jquery.maskedinput/issues/64

Add AMD API support ( https://github.com/amdjs/amdjs-api/wiki/AMD ) using the boiler plate example here (https://github.com/umdjs/umd/blob/master/jqueryPlugin.js ).

If there is no AMD compliant loader present, it passes the global jQuery object into the module as it did before.
