### PR TITLE
Setting to disable autoclear to a single input

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -55,7 +55,8 @@
 			}
 			settings = $.extend({
 				placeholder: "_",
-				completed: null
+				completed: null,
+				autoclear: true
 			}, settings);
 
 			var defs = $.mask.definitions;
@@ -241,9 +242,11 @@
 						($.browser.msie ? moveCaret:function(){setTimeout(moveCaret,0)})();
 					})
 					.bind("blur.mask", function() {
-						checkVal();
-						if (input.val() != focusText)
-							input.change();
+						if (settings.autoclear) {
+							checkVal();
+							if (input.val() != focusText)
+								input.change();
+						}
 					})
 					.bind("keydown.mask", keydownEvent)
 					.bind("keypress.mask", keypressEvent)


### PR DESCRIPTION
This is a simple extension to your great plugin. If you pass the setting autoclear:false it doesn't clear the input on blur.

I needed this on my project and I'm sure other people will like it too.
