### PR TITLE
Unexpected `completed` event behavior

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -166,7 +166,7 @@
 								writeBuffer();
 								var next = seekNext(p);
 								input.caret(next);
-								if (settings.completed && (buffer.indexOf(settings.placeholder) === -1))
+								if (settings.completed && ($.inArray(settings.placeholder, buffer) === -1))
 									settings.completed.call(input);
 							}
 						}


### PR DESCRIPTION
At the moment it is possible to skip the whole mask by moving the cursor to its last position, typing in just one valid character and `completed` events gets fired. This, in my opinion, is not the expected behavior.
