### PR TITLE
Add ability to handle invalid data on blur

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -16,6 +16,10 @@
         $("#eyescript").mask("~9.99 ~9.99 999");
         $("#po").mask("PO: aaa-999-***");
 		$("#pct").mask("99%");
+	$("#handleinvalid").mask("999", {invalid: function(){
+		alert($(this).mask() + " is invalid, need 3 digits");
+		return 1; // refocus text field
+	}});
 
         $("input").blur(function() {
             $("#info").html("Unmasked value: " + $(this).mask());
@@ -38,6 +42,7 @@
 		<tr><td>Eye Script</td><td><input id="eyescript" type="text" tabindex="6"/></td><td>~9.99 ~9.99 999</td></tr>
 		<tr><td>Purchase Order</td><td><input id="po" type="text" tabindex="6"/></td><td>aaa-999-***</td></tr>
 		<tr><td>Percent</td><td><input id="pct" type="text" tabindex="6"/></td><td>99%</td></tr>
+                <tr><td>Handle Invalid</td><td><input id="handleinvalid" type="text" tabindex="6"/></td><td>999</td></tr>
 </table>
 <div id="info"></div>
 </body>

--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -55,7 +55,8 @@
 			}
 			settings = $.extend({
 				placeholder: "_",
-				completed: null
+				completed: null,
+				invalid: null
 			}, settings);
 
 			var defs = $.mask.definitions;
@@ -63,6 +64,7 @@
 			var partialPosition = mask.length;
 			var firstNonMaskPos = null;
 			var len = mask.length;
+			var refocusing = false;
 
 			$.each(mask.split(""), function(i, c) {
 				if (c == '?') {
@@ -183,7 +185,7 @@
 
 				function writeBuffer() { return input.val(buffer.join('')).val(); };
 
-				function checkVal(allow) {
+				function verifyVal() {
 					//try to place characters where they belong
 					var test = input.val();
 					var lastMatch = -1;
@@ -205,14 +207,22 @@
 							lastMatch = i;
 						}
 					}
-					if (!allow && lastMatch + 1 < partialPosition) {
+					return {
+						lastMatch: lastMatch, 
+							i: i
+					};
+				}
+				function checkVal(allow) {
+					var x = verifyVal();
+
+					if (!allow && x.lastMatch + 1 < partialPosition) {
 						input.val("");
 						clearBuffer(0, len);
-					} else if (allow || lastMatch + 1 >= partialPosition) {
+					} else if (allow || x.lastMatch + 1 >= partialPosition) {
 						writeBuffer();
-						if (!allow) input.val(input.val().substring(0, lastMatch + 1));
+						if (!allow) input.val(input.val().substring(0, x.lastMatch + 1));
 					}
-					return (partialPosition ? i : firstNonMaskPos);
+					return (partialPosition ? x.i : firstNonMaskPos);
 				};
 
 				input.data($.mask.dataName,function(){
@@ -230,8 +240,17 @@
 					})
 					.bind("focus.mask", function() {
 						focusText = input.val();
-						var pos = checkVal();
-						writeBuffer();
+						var pos;
+						if(refocusing)
+						{
+							refocusing = false;
+							pos = checkVal(true);
+						}
+						else {
+							pos = checkVal();
+							writeBuffer();
+						}
+
 						var moveCaret=function(){
 							if (pos == mask.length)
 								input.caret(0, pos);
@@ -241,9 +260,24 @@
 						($.browser.msie ? moveCaret:function(){setTimeout(moveCaret,0)})();
 					})
 					.bind("blur.mask", function() {
-						checkVal();
+						var x = verifyVal();
+						if(x.lastMatch < firstNonMaskPos) {
+							input.val("");
+							clearBuffer(0, len);
+						}
+						else if(x.lastMatch + 1 < partialPosition) {
+							if(settings.invalid && settings.invalid()) {
+								setTimeout(function() {refocusing = true; input.focus();}, 0);
+								return;
+							}
+						input.val("");
+						clearBuffer(0, len);
+						} else if (x.lastMatch + 1 >= partialPosition) {
+							writeBuffer();
+							input.val(input.val().substring(0, x.lastMatch + 1));
+						}
 						if (input.val() != focusText)
-							input.change();
+						input.change();
 					})
 					.bind("keydown.mask", keydownEvent)
 					.bind("keypress.mask", keypressEvent)

--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -266,7 +266,7 @@
 							clearBuffer(0, len);
 						}
 						else if(x.lastMatch + 1 < partialPosition) {
-							if(settings.invalid && settings.invalid()) {
+							if(settings.invalid && settings.invalid.call(input)) {
 								setTimeout(function() {refocusing = true; input.focus();}, 0);
 								return;
 							}


### PR DESCRIPTION
Now you can handle data that does not satisfy the mask on blur.

It's used by registering a handler under the key `invalid`, which then is called when the input loses focus.  If the function returns 0, normal behavior occurs (the field is cleared).  However, if the function returns 1, then the input is refocused, and the invalid data is left alone.

This only happens on blur, so invalid data on focus will still be cleared.

Tested on firefox 13.0 linux.
