### PR TITLE
Support to change default placeholder

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -7,7 +7,7 @@
 (function($) {
 	var pasteEventName = ($.browser.msie ? 'paste' : 'input') + ".mask";
 	var iPhone = (window.orientation != undefined);
-
+ 
 	$.mask = {
 		//Predefined character definitions
 		definitions: {
@@ -15,7 +15,8 @@
 			'a': "[A-Za-z]",
 			'*': "[A-Za-z0-9]"
 		},
-		dataName:"rawMaskFn"
+		dataName: "rawMaskFn",
+		placeholder: '_',
 	};
 
 	$.fn.extend({
@@ -54,7 +55,7 @@
 				return input.data($.mask.dataName)();
 			}
 			settings = $.extend({
-				placeholder: "_",
+				placeholder: $.mask.placeholder, // Load default placeholder
 				completed: null
 			}, settings);
 


### PR DESCRIPTION
I've added a way to change the default placeholder.
Simple use: 

``` javascript
$.mask.placeholder = '-';
```

before all definitions of masks.

This way:

``` javascript
$(element).mask('99-99',{placeholder: '_'});
```

is valid too.
