### PR TITLE
Fixing browser-lockup issue.

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -232,13 +232,13 @@
 						focusText = input.val();
 						var pos = checkVal();
 						writeBuffer();
-						var moveCaret=function(){
+						var moveCaret=function(input){
 							if (pos == mask.length)
 								input.caret(0, pos);
 							else
 								input.caret(pos);
 						};
-						($.browser.msie ? moveCaret:function(){setTimeout(moveCaret,0)})();
+						($.browser.msie ? moveCaret(input):function(){setTimeout(moveCaret(input),0)})();
 					})
 					.bind("blur.mask", function() {
 						checkVal();


### PR DESCRIPTION
When a masked field has focus, a user might click out of the browser
window.  Then when a user clicks back into that input field (before the
browser has focus), a recursive loop seems to lockup the browser and
crash it.

This fix was submitted by Bryan Drenner to me to submit online here.
