### PR TITLE
Avoid caret between unfilled chars

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -247,6 +247,13 @@
 					})
 					.bind("keydown.mask", keydownEvent)
 					.bind("keypress.mask", keypressEvent)
+					.bind("click.mask", function() {
+						var len = input.mask().length,
+							caret = input.caret();
+						if (caret.begin > len || caret.end > len) {
+							input.caret(Math.min(len, caret.begin), Math.min(len, caret.end));
+						}
+					})
 					.bind(pasteEventName, function() {
 						setTimeout(function() { input.caret(checkVal(true)); }, 0);
 					});


### PR DESCRIPTION
When I click in the input:focus, it put the caret in the position I clicked. It is a usability issue to me, because people do not check where the caret is. This patch limit the caret to the length of filled mask.
