### PR TITLE
IE7 fix

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -19,7 +19,7 @@ $.mask = {
 		'*': "[A-Za-z0-9]"
 	},
 	dataName: "rawMaskFn",
-	placeholder: '_',
+	placeholder: '_'
 };
 
 $.fn.extend({


### PR DESCRIPTION
Hi! IE < 8 produce error if object has comma after last property.
