### PR TITLE
Corrected javascript syntax for defining object properties 

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -1,3 +1,7 @@
+/*!
+	jQuery MaskedInput
+	license: http://www.opensource.org/licenses/mit-license.php
+*/
 function getPasteEvent() {
     var el = document.createElement('input'),
         name = 'onpaste';


### PR DESCRIPTION
Was breaking IE7

Also added a license
