### PR TITLE
Extra comma in object definition.

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -19,7 +19,7 @@ $.mask = {
 		'*': "[A-Za-z0-9]"
 	},
 	dataName: "rawMaskFn",
-	placeholder: '_',
+	placeholder: '_'
 };
 
 $.fn.extend({


### PR DESCRIPTION
This should fix JS errors in IE <= 8.
