### PR TITLE
Don't clobber existing data

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -322,7 +322,7 @@ $.fn.extend({
 							settings.completed.call(input);
 					}, 0);
 				});
-			checkVal(); //Perform initial check for existing values
+			input.caret(checkVal(true)); //Perform initial check for existing values
 		});
 	}
 });


### PR DESCRIPTION
If .mask() was called on an edit box that already contained data, it would wipe that data out. This change keeps the (matching) data and sets the cursor position properly. It looks like the code intended to do this all along, but it didn't actually :)
