### PR TITLE
Add ins/ovr mode settings as input method

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -73,7 +73,8 @@ $.fn.extend({
 		}
 		settings = $.extend({
 			placeholder: $.mask.placeholder, // Load default placeholder
-			completed: null
+			completed: null,
+			mode: 'ins' // Input mode: 'ins' for insert at caret position, 'ovr' for overwrite next position 
 		}, settings);
 
 
@@ -200,14 +201,18 @@ $.fn.extend({
 				} else if (k) {
 					if (pos.end - pos.begin !== 0){
 						clearBuffer(pos.begin, pos.end);
-						shiftL(pos.begin, pos.end-1);
+						if(settings.mode == 'ins') {
+							shiftL(pos.begin, pos.end-1);
+						}
 					}
 
 					p = seekNext(pos.begin - 1);
 					if (p < len) {
 						c = String.fromCharCode(k);
 						if (tests[p].test(c)) {
-							shiftR(p);
+							 if(settings.mode == 'ins') {
+								shiftR(p);
+							}
 
 							buffer[p] = c;
 							writeBuffer();


### PR DESCRIPTION
I have added this overwrite mode to the plugin to fix an issue when edition dates.
The default behaviour of the plugin is to insert typed character, as a consequence the end of the input might be lost, if the user didn't delete the content before inserting the new content.

Using a field with a date-time format (99/99/99 99:99) and try to change the month, you often end with this:

Before: ![before](https://f.cloud.github.com/assets/683264/729514/7ccfdc80-e235-11e2-82a3-13b488503c53.png)
While editing (change 01 to 02) : ![inserted](https://f.cloud.github.com/assets/683264/729515/82e34f76-e235-11e2-918a-82f16a80ac10.png)
After delete : ![deleted](https://f.cloud.github.com/assets/683264/729518/874ca814-e235-11e2-962b-2d5780fd157f.png)
