### PR TITLE
Fix for chrome browser on Android

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -339,7 +339,7 @@ $.fn.extend({
 							settings.completed.call(input);
 					}, 0);
 				});
-                if (chrome) {
+                if (chrome && android) {
                     input.bind("keyup.mask", keypressEvent);
                 }
 			checkVal(); //Perform initial check for existing values


### PR DESCRIPTION
On a Samsung Galaxy, Chrome version 28 does not throw the keypress event.

Here is a fix for that.

Actually that last if statement should be if (chrome && android) {
