### PR TITLE
Properly closed mask object definition to prevent JavaScript error in IE7

### DIFF
--- a/dist/jquery.maskedinput.js
+++ b/dist/jquery.maskedinput.js
@@ -26,7 +26,7 @@ $.mask = {
 		'*': "[A-Za-z0-9]"
 	},
 	dataName: "rawMaskFn",
-	placeholder: '_',
+	placeholder: '_'
 };
 
 $.fn.extend({


### PR DESCRIPTION
Unclosed object generates a JavaScript error in IE7: "Expected identifier, string, or number"

Also see: http://stackoverflow.com/questions/2149762/possible-cases-for-javascript-error-expected-identifier-string-or-number
