### PR TITLE
Clear buffer in checkVal() to fix input duplication

### DIFF
--- a/dist/jquery.maskedinput.js
+++ b/dist/jquery.maskedinput.js
@@ -265,6 +265,7 @@ $.fn.extend({
 							}
 						}
 						if (pos > test.length) {
+						    clearBuffer(i + 1, len);
 							break;
 						}
 					} else if (buffer[i] === test.charAt(pos) && i !== partialPosition) {


### PR DESCRIPTION
I ran into an issue with masking input fields when entering values at the end of the mask, leaving the field, then re-entering.  When leaving the field, the input would shift left, then when re-entering the field the left shifted value would remain, but the original value would also be present.  I'll show an example below:

Step 1. Click or tab into an empty input and you will see an empty mask: `(___) ___-____`
Step 2. Enter a value at the end of the mask : `(___) ___-__34`
Step 3. Leave the input and the value shifts to the left: `(34_) ___-____`
Step 4. Click or tab back into the input and both the shifted and original values appear: `(34_) ___-__34`

In order to fix this issue, I added a line to clear the remaining parts of the buffer after the value is shifted to the left.

I tried to run the unit tests and it appeared the ones that passed before my change stll passed after, but I'm very new to jquery unit tests.  If you have any suggestions for what sort of tests I could do for this fix, I'll happily add them.

I did not make this change to the minified version, but I can do so if you let me know what your favorite minifier is.
