### PR TITLE
Fix for masked TEXTAREA in IE8

### DIFF
--- a/spec/IE8.Spec.js
+++ b/spec/IE8.Spec.js
@@ -1,11 +1,18 @@
 feature("IE8 bugs", function() {
 
 	var enterKeyEvent = $.Event('keydown.mask');
-    enterKeyEvent.which = enterKeyEvent.keyCode = 13;
+	enterKeyEvent.which = enterKeyEvent.keyCode = 13;
+
+	var textarea;
+    afterEach(function() {
+        if (!textarea) return;
+        textarea.remove();
+        textarea=null;
+    });
 
     story('User tries enter value into masked TEXTAREA',function(){
 
-    	scenario("Using plain INPUT",function(){
+    	scenario("Using INPUT",function(){
             given("a mask 9999",function(){
             	input.mask("9999");
             });
@@ -17,12 +24,9 @@ feature("IE8 bugs", function() {
             });
         });
 
-
-    	var textarea;
-    	textarea = $("<textarea/>").appendTo(document.body).focus();
-
-    	scenario("Using plain TEXTAREA",function(){
+    	scenario("Using TEXTAREA",function(){
             given("a mask 9999",function(){
+            	textarea = $("<textarea/>").appendTo("body").focus();
             	textarea.mask("9999");
             });
             when("typing 1234",function(){
@@ -34,4 +38,5 @@ feature("IE8 bugs", function() {
         });
 
     });
+
 });

--- a/spec/IE8.Spec.js
+++ b/spec/IE8.Spec.js
@@ -1,0 +1,37 @@
+feature("IE8 bugs", function() {
+
+	var enterKeyEvent = $.Event('keydown.mask');
+    enterKeyEvent.which = enterKeyEvent.keyCode = 13;
+
+    story('User tries enter value into masked TEXTAREA',function(){
+
+    	scenario("Using plain INPUT",function(){
+            given("a mask 9999",function(){
+            	input.mask("9999");
+            });
+            when("typing 1234",function(){
+            	input.mashKeys("1234").trigger(enterKeyEvent);;
+            });
+            then("value should be correct",function(){
+                expect(input).toHaveValue("1234");
+            });
+        });
+
+
+    	var textarea;
+    	textarea = $("<textarea/>").appendTo(document.body).focus();
+
+    	scenario("Using plain TEXTAREA",function(){
+            given("a mask 9999",function(){
+            	textarea.mask("9999");
+            });
+            when("typing 1234",function(){
+            	textarea.mashKeys("1234").trigger(enterKeyEvent);
+            });
+            then("value should be correct",function(){
+                expect(textarea).toHaveValue("1234");
+            });
+        });
+
+    });
+});

--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -53,9 +53,24 @@ $.fn.extend({
 				begin = this[0].selectionStart;
 				end = this[0].selectionEnd;
 			} else if (document.selection && document.selection.createRange) {
-				range = document.selection.createRange();
-				begin = 0 - range.duplicate().moveStart('character', -100000);
-				end = begin + range.text.length;
+				/*
+					range = document.selection.createRange();
+					begin = 0 - range.duplicate().moveStart('character', -100000);
+					end = begin + range.text.length;
+				*/
+				// fwo - above doesn't work in IE8 + TEXTAREA
+				// the problem: range.duplicate().moveStart('character', -100000) returns strange value for TEXTAREA
+				// solution: http://stackoverflow.com/questions/3053542/how-to-get-the-start-and-end-points-of-selection-in-text-area/3053640#3053640
+				// tested: IE8.Spec.js
+		        var bookmark = document.selection.createRange().getBookmark();
+		        var sel = this[0].createTextRange();
+		        var bfr = sel.duplicate();
+		        sel.moveToBookmark(bookmark);
+		        bfr.setEndPoint("EndToStart", sel);
+		        begin = bfr.text.length;
+		        end = bfr.text.length+sel.text.length;
+		        // fwo - end
+
 			}
 			return { begin: begin, end: end };
 		}


### PR DESCRIPTION
Hi, 

Thank you for great piece of code that save my time. 

When I attached it to my code, my users which uses old IE8 reported that masked input doesn't work. I used your code to mask TEXTAREA. Surprising in IE8 maskedinput works with INPUT's, but breaks on TEXTAREA. I looked into your code and prepared a fix and IE8.Spec.js test case.  

Thanks, 
Filip 
