### PR TITLE
Patch for CSP Violation on FireFox OS

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -246,7 +246,13 @@ $.fn.extend({
 							next = seekNext(p);
 
 							if(android){
-								setTimeout($.proxy($.fn.caret,input,next),0);
+								//Path for CSP Violation on FireFox OS 1.1
+								var proxy = function()
+								{
+									$.proxy($.fn.caret,input,next);
+								}
+
+								setTimeout(proxy,0);
 							}else{
 								input.caret(next);
 							}


### PR DESCRIPTION
Patch for CSP Violation on FireFox OS that causes privileged and certified apps not pass in Validation due CSP violation. Enclosing the following call in an anonymous function make it CSP compatible
