### PR TITLE
Small fix for inputs with "required" attributes

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -304,7 +304,7 @@ $.fn.extend({
 					if (settings.autoclear || buffer.join('') === defaultBuffer) {
 						// Invalid value. Remove it and replace it with the
 						// mask, which is the default behavior.
-						input.val("");
+						if(input.val()) input.val("");
 						clearBuffer(0, len);
 					} else {
 						// Invalid value, but we opt to show the value to the


### PR DESCRIPTION
It's a small fix. If the input has the html5 "required" attribute, the input gets the "invalid" mark from the browser, because the script changes the value of the input.
With this fix it is working better maybe.
Correct me if I'm wrong. :)
