### PR TITLE
Fix caret position on Android

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -247,10 +247,9 @@ $.fn.extend({
 
 							if(android){
 								//Path for CSP Violation on FireFox OS 1.1
-								var proxy = function()
-								{
-									$.proxy($.fn.caret,input,next);
-								}
+								var proxy = function() {
+									$.proxy($.fn.caret,input,next)();
+								};
 
 								setTimeout(proxy,0);
 							}else{


### PR DESCRIPTION
Fixes bug introduced in 23e6f693 (PR #196) - function created by `$.proxy` was never executed.
