### PR TITLE
Fix bug where input didn't complete if final character was mid-input

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -257,7 +257,7 @@ $.fn.extend({
 								input.caret(next);
 							}
 
-							if (settings.completed && next >= len) {
+							if (settings.completed && (next >= len || buffer.indexOf(settings.placeholder) == -1)) {
 								settings.completed.call(input);
 							}
 						}


### PR DESCRIPTION
The previous completion callback was only called if the final character
typed was also the last character in the masked input.  For example if I
have a date mask (99/99/9999), if I type 03/27/2014 in that order, it
will fire the completion callback without issue.  But if I go back and
backspace the 27 to a 28, the callback wouldn't fire.
