### PR TITLE
remapping input characters

### DIFF
--- a/spec/Setup.Spec.js
+++ b/spec/Setup.Spec.js
@@ -1,4 +1,4 @@
-feature("Masking an Input", function() {	
+feature("Masking an Input", function() {
 	scenario('Applying a mask to an already masked input',function(){
 		given("an input with two masks", function(){
 			input
@@ -12,6 +12,21 @@ feature("Masking an Input", function() {
 
 		then("value should be correct",function(){
 			expect(input).toHaveValue('1_');
+		});
+	});
+
+	scenario('Applying a mask and re-mapping rule',function(){
+		given("an input with re-mapping rules", function(){
+			input
+			.mask("99", {reMap:{'1':'9'}});
+		});
+
+		when("typing two numbers",function(){
+			input.mashKeys("18");
+		});
+
+		then("value should be correct",function(){
+			expect(input).toHaveValue('98');
 		});
 	});
 });

--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -23,7 +23,8 @@ $.mask = {
 	},
 	autoclear: true,
 	dataName: "rawMaskFn",
-	placeholder: '_'
+	placeholder: '_',
+	reMap: {}
 };
 
 $.fn.extend({
@@ -78,7 +79,8 @@ $.fn.extend({
 		settings = $.extend({
 			autoclear: $.mask.autoclear,
 			placeholder: $.mask.placeholder, // Load default placeholder
-			completed: null
+			completed: null,
+			reMap: $.mask.reMap
 		}, settings);
 
 
@@ -238,6 +240,11 @@ $.fn.extend({
 					p = seekNext(pos.begin - 1);
 					if (p < len) {
 						c = String.fromCharCode(k);
+						/* a chance to remap inputs */
+						if(c in settings.reMap)
+						{
+							c = settings.reMap[c];
+						}
 						if (tests[p].test(c)) {
 							shiftR(p);
 


### PR DESCRIPTION
Was using maskedinput for restricted-alphabet keys and ran into a situation where we needed to re-map some erroneous entries (i.e., 'o' -> '0') instead of simply blocking the disallowed character. This pull implements a reMap setting. The above transform would be accomplished like:
`$("input.key").mask("xxxx-xxxx-xxxx",{placeholder:"x", reMap:{'o': '0'}});`

Presumptive, but thought it might be a feature worth sending up. Did my best to include a relevant test. 

Cheers
