### PR TITLE
Add custom date placeholders

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -19,11 +19,21 @@ $.mask = {
 	definitions: {
 		'9': "[0-9]",
 		'a': "[A-Za-z]",
-		'*': "[A-Za-z0-9]"
+		'*': "[A-Za-z0-9]",
+		'D': "[0-9]",
+		'M': "[0-9]",
+		'Y': "[0-9]"
 	},
 	autoclear: true,
 	dataName: "rawMaskFn",
-	placeholder: '_'
+	placeholders : {
+		'9': "_",
+		'a': "_",
+		'*': "_",
+		'D': "D",
+		'M': "M",
+		'Y': "Y"
+	}
 };
 
 $.fn.extend({
@@ -66,6 +76,7 @@ $.fn.extend({
 	mask: function(mask, settings) {
 		var input,
 			defs,
+			phs,
 			tests,
 			partialPosition,
 			firstNonMaskPos,
@@ -83,6 +94,7 @@ $.fn.extend({
 
 
 		defs = $.mask.definitions;
+		phs = $.mask.placeholders;
 		tests = [];
 		partialPosition = len = mask.length;
 		firstNonMaskPos = null;
@@ -107,7 +119,7 @@ $.fn.extend({
 				mask.split(""),
 				function(c, i) {
 					if (c != '?') {
-						return defs[c] ? settings.placeholder : c;
+						return defs[c] ? phs[c] : c;
 					}
 				}),
 				defaultBuffer = buffer.join(''),
@@ -135,7 +147,7 @@ $.fn.extend({
 					if (tests[i]) {
 						if (j < len && tests[i].test(buffer[j])) {
 							buffer[i] = buffer[j];
-							buffer[j] = settings.placeholder;
+							buffer[i] = phs[mask.charAt(i)];
 						} else {
 							break;
 						}
@@ -153,7 +165,7 @@ $.fn.extend({
 					j,
 					t;
 
-				for (i = pos, c = settings.placeholder; i < len; i++) {
+				for (i = pos, c = phs[mask.charAt(i)]; i < len; i++) {
 					if (tests[i]) {
 						j = seekNext(i);
 						t = buffer[i];
@@ -269,7 +281,7 @@ $.fn.extend({
 				var i;
 				for (i = start; i < end && i < len; i++) {
 					if (tests[i]) {
-						buffer[i] = settings.placeholder;
+						buffer[i] = phs[mask.charAt(i)];
 					}
 				}
 			}
@@ -286,7 +298,7 @@ $.fn.extend({
 
 				for (i = 0, pos = 0; i < len; i++) {
 					if (tests[i]) {
-						buffer[i] = settings.placeholder;
+						buffer[i] = phs[mask.charAt(i)];
 						while (pos++ < test.length) {
 							c = test.charAt(pos - 1);
 							if (tests[i].test(c)) {
@@ -325,7 +337,7 @@ $.fn.extend({
 
 			input.data($.mask.dataName,function(){
 				return $.map(buffer, function(c, i) {
-					return tests[i]&&c!=settings.placeholder ? c : null;
+					return tests[i] && c != phs[mask.charAt(i)] ? c : null;
 				}).join('');
 			});
 


### PR DESCRIPTION
This is a patch by germanwings i found while booking a flight ;)
It adds new placeholders for (birth)dates that can be overwritten to localize them by setting:

$.mask.placeholders['D'] = 'T';

So instead of having underlines, you can now have DD.MM.YYYY as placeholder. Very nice!

This can also be extended more to use Hour and Second for example.
