### PR TITLE
Clear buffer after input blur

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -169,7 +169,7 @@ $.fn.extend({
 
       function blurEvent(e) {
           checkVal();
-
+          clearBuffer(0, len);
           if (input.val() != focusText)
             input.change();
       }


### PR DESCRIPTION
When you type in the middle of the mask (ie. "(**_) __2-__**" for a phone number) if the mask is optional, the number will jump to the beginning of the mask on blur (ie. the input value becomes "(2" ) Then when you click back in the input the buffer will add the 2 back in the position it was in when you blurred the input (ie. the input value becomes "(2__) **2-__**" ) This makes it necessary to clear the buffer on input blur
