### PR TITLE
Clear buffer when shifting characters to the left

### DIFF
--- a/spec/Focus.Spec.js
+++ b/spec/Focus.Spec.js
@@ -126,6 +126,23 @@ feature("Leaving A Masked Input",function(){
 			expect(input).toHaveValue("1_");
 		});
 	});
+
+	scenario("Shifts characters left on blur with autoclear false",function(){
+		given("a mask with 10 placeholders",function(){
+			input.mask("(999) 999-9999", { autoclear: false });
+		});
+		when("focusing input",function(){
+			input.focus();
+		});
+		waits(20);
+		when("typing characters at the end of the mask and blurring",function(){
+			input.caret(12);
+			input.mashKeys("44").blur();
+		});
+		then("characters should shift left to beginning of mask",function(){
+			expect(input).toHaveValue("(44_) ___-____");
+		});
+	});
 });
 
 feature("Optional marker",function(){

--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -305,6 +305,7 @@ $.fn.extend({
 							}
 						}
 						if (pos > test.length) {
+							clearBuffer(i + 1, len);
 							break;
 						}
 					} else if (buffer[i] === test.charAt(pos) && i !== partialPosition) {


### PR DESCRIPTION
This PR fixes a bug where if you type characters at the end of an input mask with autoclear set to false and then blur/focusout, the typed characters are shifted to the beginning of the mask (left) but then also duplicated at their original typed position... resulting in some wacky entries like "(44_) ___ - __44". Further focusing / blurring on the input field would repeat this strange duplication + shifting issue.

This fix duplicates the solution found in https://github.com/digitalBush/jquery.maskedinput/pull/175 and adds a test.

Now, we're clearing the buffer (removing trailing characters) if your cursor position is greater than the length of your input after the characters have been shifted left.
