### PR TITLE
Added onError callback

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -34,7 +34,8 @@ $.mask = {
 	},
 	autoclear: true,
 	dataName: "rawMaskFn",
-	placeholder: '_'
+	placeholder: '_',
+	onInvalid: null,
 };
 
 $.fn.extend({
@@ -93,7 +94,8 @@ $.fn.extend({
 		settings = $.extend({
 			autoclear: $.mask.autoclear,
 			placeholder: $.mask.placeholder, // Load default placeholder
-			completed: null
+			completed: null,
+			onError: null
 		}, settings);
 
 
@@ -311,7 +313,9 @@ $.fn.extend({
                             if(pos.begin <= lastRequiredNonMaskPos){
 		                         tryFireCompleted();
                              }
-						}
+						}else if(settings.onError){
+                            settings.onError.call(input);
+                        }
 					}
 					e.preventDefault();
 				}


### PR DESCRIPTION
When a user cannot change a form input due to masks bound to it, it could be quite misleading, mostly in case when a mask is complicated. This modification allows to set a callback when an incorrect symbol was typed.
