### PR TITLE
Added  overwrite mode and autofocus disable optional settings

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -24,6 +24,8 @@ $.mask = {
 		'a': "[A-Za-z]",
 		'*': "[A-Za-z0-9]"
 	},
+        overwrite: false,
+        autofocus: true,
 	autoclear: true,
 	dataName: "rawMaskFn",
 	placeholder: '_'
@@ -83,6 +85,8 @@ $.fn.extend({
 		}
 
 		settings = $.extend({
+			overwrite: $.mask.overwrite,
+			autofocus: $.mask.autofocus,
 			autoclear: $.mask.autoclear,
 			placeholder: $.mask.placeholder, // Load default placeholder
 			completed: null
@@ -160,6 +164,7 @@ $.fn.extend({
 					return;
 				}
 
+				if (!settings.overwrite)
 				for (i = begin, j = seekNext(end); i < len; i++) {
 					if (tests[i]) {
 						if (j < len && tests[i].test(buffer[j])) {
@@ -182,6 +187,7 @@ $.fn.extend({
 					j,
 					t;
 
+				if (!settings.overwrite)
 				for (i = pos, c = getPlaceholder(pos); i < len; i++) {
 					if (tests[i]) {
 						j = seekNext(i);
@@ -401,12 +407,14 @@ $.fn.extend({
                         if(input.get(0) !== document.activeElement){
                             return;
                         }
-						writeBuffer();
-						if (pos == mask.replace("?","").length) {
-							input.caret(0, pos);
-						} else {
-							input.caret(pos);
-						}
+                        			if (settings.autofocus) {
+							writeBuffer();
+							if (pos == mask.replace("?","").length) {
+								input.caret(0, pos);
+							} else {
+								input.caret(pos);
+							}
+                        			}
 					}, 10);
 				})
 				.on("blur.mask", blurEvent)


### PR DESCRIPTION
Added optional settings to enable overwrite mode (do not shift characters during typing or backspacing) and to avoid autofocusing when clicking on an input field (it can be annoying since it resets field content at the very first character typed and it's probably not what an user wants when the field is already in its completed state).
