### PR TITLE
Correctly identify main file for bower.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Josh Bush (digitalbush.com)"
   ],
   "description": "jQuery Masked Input Plugin",
-  "main": "./dist/jquery.maskedinput.js",
+  "main": "./src/jquery.maskedinput.js",
   "moduleType": [
     "es6"
   ],

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery.maskedinput",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "homepage": "http://digitalbush.com/projects/masked-input-plugin/",
   "authors": [
     "Josh Bush (digitalbush.com)"


### PR DESCRIPTION
No longer using ```dist```, but ```src```.