### PR TITLE
Ensuring caret does not execute if the element does not have focus.  …

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -34,7 +34,7 @@ $.fn.extend({
 	caret: function(begin, end) {
 		var range;
 
-		if (this.length === 0 || this.is(":hidden")) {
+		if (this.length === 0 || this.is(":hidden") || this.get(0) !== document.activeElement) {
 			return;
 		}
 


### PR DESCRIPTION
…This fixes an issue in IE11 where the user may not be able to move to another input element.