### PR TITLE
Forcing mask to string

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -94,6 +94,8 @@ $.fn.extend({
 		partialPosition = len = mask.length;
 		firstNonMaskPos = null;
 
+		mask = String(mask);
+
 		$.each(mask.split(""), function(i, c) {
 			if (c == '?') {
 				len--;


### PR DESCRIPTION
This code:

$('[data-masked]').each(function() {
	$(this).mask($(this).data('masked'));
});

Will give an error, when data-masked="99999" ... the $(this).data returns a number object, not string.