### PR TITLE
fixed cursor keys being cancelled in Firefox, because of keypress being called

### DIFF
--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -284,7 +284,7 @@ $.fn.extend({
 					c,
 					next;
 
-				if (e.ctrlKey || e.altKey || e.metaKey || k < 32) {//Ignore
+				if (e.ctrlKey || e.altKey || e.metaKey || k < 41) {//Ignore
 					return;
 				} else if ( k && k !== 13 ) {
 					if (pos.end - pos.begin !== 0){


### PR DESCRIPTION
Fixes issue https://github.com/digitalBush/jquery.maskedinput/issues/275
Chrome and IE won't call keypress for cursor keys, Firefox does so this event should not be cancelled
