### PR TITLE
Trigger input

### DIFF
--- a/spec/Event.Spec.js
+++ b/spec/Event.Spec.js
@@ -1,0 +1,20 @@
+feature("Events", function() {
+	scenario("the event 'input' is triggered when user types something",function(){
+		var inputEventCount = 0;
+		given("an input with mask definition", function(){
+			input
+			.mask('9999')
+			.focus();
+		});
+		given("the input has a listener for the 'input' event", function(){
+			input
+			.on('input',function(){inputEventCount++;});
+		});
+		when("user types something",function(){
+			input.mashKeys(function(keys){keys.type('12')});
+		});
+		then("the listener is called for each key",function(){
+			expect(inputEventCount).toEqual(2);
+		});
+	});
+});

--- a/src/jquery.maskedinput.js
+++ b/src/jquery.maskedinput.js
@@ -318,6 +318,8 @@ $.fn.extend({
 						}
 					}
 					e.preventDefault();
+
+					input.trigger('input');
 				}
 			}
 


### PR DESCRIPTION
The `'input'` event is not very well known, but it's a really convenient event to use when you want to do something while an input is being modified, even before it's 'committed'.

Since `maskedInput` intercepts keypresses and modifies with JS some `<input>`, it should also trigger these `'input'` events when doing so.

Otherwise, other libraries (like the `Parsley` validation library) will not function properly (see https://github.com/guillaumepotier/Parsley.js/issues/1076)

This simple PR addresses that.

Thanks
