### PR TITLE
add main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,6 @@
   },
   "scripts": {
     "test": "grunt test"
-  }
+  },
+  "main": "src/jquery.maskedinput.js"
 }


### PR DESCRIPTION
Add «main» field for use import package from NPM to project and build with webpack, rollup and etc.
